### PR TITLE
feat(docker): Drops the need for build args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,10 @@ jobs:
     - pip install --user awscli
     - export PATH=$PATH:$HOME/.local/bin
     - eval $(aws ecr get-login --no-include-email --region eu-west-1)
-    - echo "Building for playground"
-    - docker build --build-arg WT_CONFIG=playground -t wt-search-api:$TRAVIS_BRANCH-playground .
-    - docker tag wt-search-api:$TRAVIS_BRANCH-playground 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$TRAVIS_BRANCH-playground
-    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$TRAVIS_BRANCH-playground
-    - echo "Building for demo"
-    - docker build --build-arg WT_CONFIG=demo -t wt-search-api:$TRAVIS_BRANCH-demo .
-    - docker tag wt-search-api:$TRAVIS_BRANCH-demo 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$TRAVIS_BRANCH-demo
-    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$TRAVIS_BRANCH-demo
+    - echo "Building docker image"
+    - docker build -t wt-search-api:$TRAVIS_BRANCH .
+    - docker tag wt-search-api:$TRAVIS_BRANCH 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$TRAVIS_BRANCH
+    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$TRAVIS_BRANCH
   - stage: Start service from docker with latest merged tag
     install: true
     sudo: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ RUN npm ci
 
 COPY . .
 
-ARG WT_CONFIG
-
-RUN npm run createdb
-
-CMD ["npm", "start"]
+CMD ["npm", "run", "docker-start"]
 
 EXPOSE 1918

--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ data immediately.
 - For our deployment on https://playground-api.windingtree.com, we use a Docker image.
 - You can use it in your local environment by running the following commands:
 ```sh
-$ docker build --build-arg WT_CONFIG=playground -t windingtree/wt-search-api .
+$ docker build -t windingtree/wt-search-api .
 $ docker run -p 8080:1918 -e WT_CONFIG=playground -e WT_READ_API_URL=https://playground-api.windingtree.com -e WT_BASE_API_URL=http://localhost:8080 windingtree/wt-search-api
 ```
-- After that you can access the wt-search-api on local port `8080`
-- This deployment is using a Ropsten configuration that can be found in `src/config/playground.js`
+- After that you can access the wt-search-api on local port `8080`.
+- This deployment is using a Ropsten configuration that can be found in `src/config/playground.js`.
+- This docker creates a database during image startup. That is pinned to SQLite for now.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ docker run -p 8080:1918 -e WT_CONFIG=playground -e WT_READ_API_URL=https://pla
 - After that you can access the wt-search-api on local port `8080`.
 - This deployment is using a Ropsten configuration that can be found in `src/config/playground.js`.
 - This docker creates a database during image startup. That is pinned to SQLite for now.
+You can skip this with `SKIP_DB_SETUP` environment variable.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ data immediately.
 - You can use it in your local environment by running the following commands:
 ```sh
 $ docker build -t windingtree/wt-search-api .
-$ docker run -p 8080:1918 -e WT_CONFIG=playground -e WT_READ_API_URL=https://playground-api.windingtree.com -e WT_BASE_API_URL=http://localhost:8080 windingtree/wt-search-api
+$ docker run -p 8080:1918 -e WT_CONFIG=playground -e READ_API_URL=https://playground-api.windingtree.com -e BASE_URL=http://localhost:8080 windingtree/wt-search-api
 ```
 - After that you can access the wt-search-api on local port `8080`.
 - This deployment is using a Ropsten configuration that can be found in `src/config/playground.js`.

--- a/management/createdb.js
+++ b/management/createdb.js
@@ -1,7 +1,7 @@
 const { setupDB } = require('../src/db');
 
 setupDB().then(() => {
-  console.log('Created');
+  console.log('DB is all set');
   process.exit(0);
 }, (err) => {
   console.log(`Error: ${err}`);

--- a/management/createdb.js
+++ b/management/createdb.js
@@ -1,3 +1,8 @@
+if (process.env.SKIP_DB_SETUP) {
+  console.log('Skipping DB setup');
+  process.exit(0);
+}
+
 const { setupDB } = require('../src/db');
 
 setupDB().then(() => {

--- a/management/deploy-aws.sh
+++ b/management/deploy-aws.sh
@@ -29,11 +29,11 @@ TASK_DEF="[{\"portMappings\": [{\"hostPort\": 0,\"protocol\": \"tcp\",\"containe
         \"value\": \"$WT_CONFIG\"
       },
       {
-        \"name\": \"WT_API_BASE_URL\",
+        \"name\": \"BASE_URL\",
         \"value\": \"https://$WT_CONFIG-search-api.windingtree.com\"
       },
       {
-        \"name\": \"WT_READ_API_URL\",
+        \"name\": \"READ_API_URL\",
         \"value\": \"https://$WT_CONFIG-api.windingtree.com\"
       }
     ],

--- a/management/deploy-aws.sh
+++ b/management/deploy-aws.sh
@@ -37,7 +37,7 @@ TASK_DEF="[{\"portMappings\": [{\"hostPort\": 0,\"protocol\": \"tcp\",\"containe
         \"value\": \"https://$WT_CONFIG-api.windingtree.com\"
       }
     ],
-    \"image\": \"029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$LATEST_TAG-$ENVIRONMENT\",
+    \"image\": \"029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-search-api:$LATEST_TAG\",
     \"name\": \"wt-search-api\",
     \"memoryReservation\": 128,
     \"cpu\": 128

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test-watch": "WT_CONFIG=test ./node_modules/mocha/bin/mocha --recursive --timeout 20000 --watch",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "start": "node src/index.js",
+    "docker-start": "npm run createdb && npm start",
     "dev": "WT_CONFIG=dev node src/index.js",
     "createdb-dev": "WT_CONFIG=dev node management/createdb.js",
     "createdb": "node management/createdb.js",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,8 +4,8 @@ const env = process.env.WT_CONFIG || 'dev';
 
 module.exports = Object.assign({
   port: 1918,
-  baseUrl: process.env.WT_API_BASE_URL || 'http://localhost:1918',
-  readApiUrl: process.env.WT_READ_API_URL || 'http://localhost:3000',
+  baseUrl: process.env.BASE_URL || 'http://localhost:1918',
+  readApiUrl: process.env.READ_API_URL || 'http://localhost:3000',
   logger: winston.createLogger({
     level: 'info',
     transports: [


### PR DESCRIPTION
This PR simplifies our AWS deployment by dropping the need to build the container twice (once for demo, once for playground). However, the containers are still pinned to sqlite, so it's not really that re-usable for a wider audience.